### PR TITLE
Fix leaked service bindings causing duplicate command/listening processes

### DIFF
--- a/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/ClipshareClipboardListenerPlugin.kt
+++ b/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/ClipshareClipboardListenerPlugin.kt
@@ -87,6 +87,10 @@ class ClipshareClipboardListenerPlugin : FlutterPlugin, MethodCallHandler,
     var latestWriteClipboardPkgService: ILatestWriteClipboardPkgService? = null
     val latestWriteClipboardPkgShellFileName = "readLastWriteClipboardPkg.sh"
     private var commandRunnerService: ICommandRunnerService? = null
+    private var commandRunnerServiceArgs: UserServiceArgs? = null
+    private var commandRunnerServiceConn: ServiceConnection? = null
+    @Volatile
+    private var commandRunnerBinding = false
     private val commandRunnerScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val clipboardSourceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -118,6 +122,7 @@ class ClipshareClipboardListenerPlugin : FlutterPlugin, MethodCallHandler,
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        destroyCommandRunnerService()
         channel.setMethodCallHandler(null)
         instance = null
         Shizuku.removeRequestPermissionResultListener(this);
@@ -528,49 +533,74 @@ class ClipshareClipboardListenerPlugin : FlutterPlugin, MethodCallHandler,
 
     @Synchronized
     private fun initCommandRunnerService() {
-        if (commandRunnerService != null) {
+        if (commandRunnerService != null || commandRunnerBinding) {
             return
         }
         if (currentEnv == EnvironmentType.root && commandRunnerService == null) {
             commandRunnerService = CommandRunnerService()
             return
         }
-        val serviceArgs = UserServiceArgs(
-            ComponentName(
-                config.applicationId,
-                CommandRunnerService::class.java.name
-            )
-        ).daemon(false).processNameSuffix("clipshare-command-service")
-        val serviceConn = object : ServiceConnection {
-            override fun onServiceConnected(name: ComponentName, binder: IBinder) {
-                Log.d(TAG, "onServiceConnected ${name.className}")
-                try {
-                    commandRunnerService = ICommandRunnerService.Stub.asInterface(binder)
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-
-            override fun onServiceDisconnected(name: ComponentName) {
-                try {
-                    commandRunnerService?.destroy()
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                } finally {
-                    commandRunnerService = null;
-                }
-                Log.w(TAG, "onServiceDisconnected ${name.className}")
-            }
-
+        if (commandRunnerServiceArgs == null) {
+            commandRunnerServiceArgs = UserServiceArgs(
+                ComponentName(
+                    config.applicationId,
+                    CommandRunnerService::class.java.name
+                )
+            ).daemon(false).processNameSuffix("clipshare-command-service")
         }
-        Shizuku.bindUserService(serviceArgs, serviceConn)
+        if (commandRunnerServiceConn == null) {
+            commandRunnerServiceConn = object : ServiceConnection {
+                override fun onServiceConnected(name: ComponentName, binder: IBinder) {
+                    Log.d(TAG, "onServiceConnected ${name.className}")
+                    commandRunnerBinding = false
+                    try {
+                        commandRunnerService = ICommandRunnerService.Stub.asInterface(binder)
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+
+                override fun onServiceDisconnected(name: ComponentName) {
+                    commandRunnerBinding = false
+                    try {
+                        commandRunnerService?.destroy()
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    } finally {
+                        commandRunnerService = null
+                    }
+                    Log.w(TAG, "onServiceDisconnected ${name.className}")
+                }
+            }
+        }
+        commandRunnerBinding = true
+        Shizuku.bindUserService(commandRunnerServiceArgs!!, commandRunnerServiceConn!!)
     }
 
     suspend fun waitCommandRunnerService(timeout: Long = 5000) {
         withTimeout(timeout) {
-            while (commandRunnerService == null) {
+            while (commandRunnerService == null && commandRunnerBinding) {
                 delay(50)
             }
+        }
+    }
+
+    @Synchronized
+    private fun destroyCommandRunnerService() {
+        try {
+            commandRunnerService?.destroy()
+            if (commandRunnerServiceArgs != null && commandRunnerServiceConn != null) {
+                Shizuku.unbindUserService(
+                    commandRunnerServiceArgs!!,
+                    commandRunnerServiceConn!!,
+                    true
+                )
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            commandRunnerService = null
+            commandRunnerBinding = false
         }
     }
 
@@ -771,9 +801,9 @@ class ClipshareClipboardListenerPlugin : FlutterPlugin, MethodCallHandler,
         try {
             latestWriteClipboardPkgService?.destroy()
             latestWriteClipboardPkgService = null
-            if (listeningServiceArgs != null && clipboardSourceServiceConn != null) {
+            if (clipboardSourceArgs != null && clipboardSourceServiceConn != null) {
                 Shizuku.unbindUserService(
-                    listeningServiceArgs!!,
+                    clipboardSourceArgs!!,
                     clipboardSourceServiceConn!!,
                     true
                 )

--- a/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ClipboardListenerService.kt
+++ b/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ClipboardListenerService.kt
@@ -131,14 +131,22 @@ open class ClipboardListenerService : IClipboardListenerService.Stub() {
     override fun stopListening() {
         Log.d(TAG, "stopListening")
         stopped = true
-        process?.inputStream?.close()
-        process?.outputStream?.close()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            process?.destroyForcibly()
-        } else {
-            process?.destroy()
+        stopProcess()
+    }
+
+    private fun stopProcess(){
+        try{
+            process?.inputStream?.close()
+            process?.outputStream?.close()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                process?.destroyForcibly()
+            } else {
+                process?.destroy()
+            }
+            process = null
+        }catch (_: Exception){
+
         }
-        process = null
     }
 
     /**
@@ -146,6 +154,7 @@ open class ClipboardListenerService : IClipboardListenerService.Stub() {
      */
     override fun destroy() {
         Log.i(TAG, "destroy")
+        stopProcess()
         if(!isRootMode) {
             System.exit(0)
         }

--- a/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/CommandRunnerService.kt
+++ b/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/CommandRunnerService.kt
@@ -8,9 +8,13 @@ import java.io.InputStreamReader
 
 class CommandRunnerService : ICommandRunnerService.Stub() {
     private val TAG = "CommandRunnerService"
+    private var isRootMode: Boolean = false;
 
     override fun destroy() {
         Log.i(TAG, "destroy")
+        if(!isRootMode) {
+            System.exit(0)
+        }
     }
 
     override fun exit() {
@@ -20,7 +24,7 @@ class CommandRunnerService : ICommandRunnerService.Stub() {
     override fun run(command: String, useRoot: Boolean): String {
         var process: Process? = null
         val result = StringBuilder()
-
+        isRootMode = useRoot
         try {
             process = if (useRoot) {
                 ProcessBuilder("su")

--- a/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ForegroundService.kt
+++ b/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ForegroundService.kt
@@ -342,6 +342,19 @@ class ForegroundService : Service() {
         } catch (_: Exception) {
 
         }
+        try {
+            plugin?.listeningServiceArgs?.let { args ->
+                plugin?.listeningServiceConn?.let { conn ->
+                    Shizuku.unbindUserService(args, conn, true)
+                }
+            }
+            plugin?.listeningServiceConn = null
+        } catch (e: Exception) {
+            Log.w(TAG, "unbind listening service failed", e)
+        }
+        Shizuku.removeBinderReceivedListener(onBinderReceivedListener)
+        Shizuku.removeBinderDeadListener(onBinderDeadListener)
+        stopForeground(STOP_FOREGROUND_REMOVE)
         listenerService = null
         super.onDestroy()
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.14"
+    version: "1.2.15"
   clock:
     dependency: transitive
     description:


### PR DESCRIPTION
### Motivation
- Prevent accumulation of duplicate Shizuku user-service processes caused by repeated/asynchronous binds during frequent clipboard permission checks. 
- Ensure the command-runner user service is bound only once and can be torn down cleanly when the plugin is detached. 
- Fix incorrect/unbound clipboard-source teardown and ensure the foreground listening service cleans up all Shizuku listeners and notifications to avoid leaked listening processes.

### Description
- Add `commandRunnerServiceArgs`, `commandRunnerServiceConn` and a `@Volatile` `commandRunnerBinding` flag and reuse a single `UserServiceArgs/ServiceConnection` pair to avoid concurrent duplicate binds for the `clipshare-command-service`. 
- Update `initCommandRunnerService()` to set `commandRunnerBinding` during bind and to wait only while binding is in progress (`while (commandRunnerService == null && commandRunnerBinding)`). 
- Add `destroyCommandRunnerService()` and call it from `onDetachedFromEngine()` to explicitly `destroy()` and `Shizuku.unbindUserService()` the command-runner service. 
- Fix `stopClipboardSourceService()` to unbind using `clipboardSourceArgs` (previously used the wrong args) and improve `ForegroundService.onDestroy()` to unbind the listening user service, remove Shizuku binder listeners, and call `stopForeground(STOP_FOREGROUND_REMOVE)`.

### Testing
- Attempted to assemble the Android artifact with `./gradlew -p android :clipshare_clipboard_listener:assemble`, which failed in this environment because `./gradlew` is not present in the working directory. (failed)
- Attempted to run `android/gradlew -p android assemble`, which failed because the Gradle wrapper JAR/`org.gradle.wrapper.GradleWrapperMain` is missing in this repository snapshot, so a local build could not be completed here. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2b5786b8832dadacaaf987a01c9e)