### PR TITLE
fix(android): prevent root hiddenApi app_process residue after app kill

### DIFF
--- a/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ClipboardListenerService.kt
+++ b/android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ClipboardListenerService.kt
@@ -17,6 +17,7 @@ import java.util.Locale
 open class ClipboardListenerService : IClipboardListenerService.Stub() {
     private val TAG = "ClipboardListenerService"
     private var process: Process? = null
+    private var processStdin: DataOutputStream? = null
     private var stopped: Boolean = false
     private var isRootMode: Boolean = false;
     private fun buildCommandsWithSpace(commands: Array<String>): String {
@@ -37,6 +38,7 @@ open class ClipboardListenerService : IClipboardListenerService.Stub() {
         filePath: String,
         useHiddenApi: Boolean
     ) {
+        stopped = false
         isRootMode = useRoot
         var success = false;
         if (useHiddenApi) {
@@ -90,17 +92,22 @@ open class ClipboardListenerService : IClipboardListenerService.Stub() {
                 processBuilder = ProcessBuilder(arrayOf("su").toList())
                 processBuilder.redirectErrorStream(true)
                 process = processBuilder.start()
-                val os = DataOutputStream(process!!.outputStream)
-                os.writeBytes("${buildCommandsWithSpace(commands)}\n")
-                os.flush()
+                processStdin = DataOutputStream(process!!.outputStream)
+                processStdin?.writeBytes("exec ${buildCommandsWithSpace(commands)}\n")
+                processStdin?.flush()
             } else {
                 processBuilder = ProcessBuilder(commands.toList())
                 processBuilder.redirectErrorStream(true)
                 process = processBuilder.start()
+                processStdin = null
             }
             reader = BufferedReader(InputStreamReader(process!!.inputStream))
             var line: String?
             while (reader.readLine().also { line = it } != null) {
+                if (stopped || Thread.currentThread().isInterrupted) {
+                    Log.d(TAG, "stop requested, break read loop")
+                    break
+                }
                 Log.d(TAG, line!!)
                 if (useLog) {
                     callback.onChanged(line!!)
@@ -124,6 +131,7 @@ open class ClipboardListenerService : IClipboardListenerService.Stub() {
             error = true;
         } finally {
             reader?.close()
+            processStdin = null
         }
         return error
     }
@@ -136,6 +144,13 @@ open class ClipboardListenerService : IClipboardListenerService.Stub() {
 
     private fun stopProcess(){
         try{
+            processStdin?.writeBytes("exit\n")
+            processStdin?.flush()
+        } catch (_: Exception){
+        }
+        try{
+            processStdin?.close()
+            processStdin = null
             process?.inputStream?.close()
             process?.outputStream?.close()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
### Motivation

- On some devices the `app_process` started in root + hiddenApi mode could survive after the app is force-stopped, causing a residual dex listener process. 
- The root path previously launched an interactive `su` and injected `app_process` into its stdin, which can allow the child to become orphaned when the parent is killed. 
- The change aims to make the root-launched listener replace the shell and improve teardown so children are terminated reliably.

### Description

- Reset `stopped` at the start of `startListening` so a new session can run after a prior stop. 
- When using root, write `exec <command>` into `su` instead of starting the command as an interactive child, reducing parent/child separation risk. 
- Keep a handle to the root shell stdin in `processStdin` and attempt to send `exit` + `flush` and then close it during `stopProcess` before destroying the process. 
- Break out of the read loop promptly when `stopped` is set or the thread is interrupted to avoid hanging reads. 
- Files changed: `android/src/main/kotlin/top/coclyun/clipshare/clipboard_listener/service/ClipboardListenerService.kt`.

### Testing

- Ran Kotlin compilation via Gradle with `./gradlew :compileDebugKotlin`, which failed because the repository snapshot is missing the Gradle wrapper runtime (`org.gradle.wrapper.GradleWrapperMain`), so compile could not be executed in this environment. 
- No further automated tests were available/ran in this environment due to the wrapper/runtime limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3020fd38832db18465e2483d74e8)