### PR TITLE
Remove orphaned onClipboardChanged declaration that breaks Linux -Werror builds

### DIFF
--- a/linux/clipshare_clipboard_listener_plugin_private.h
+++ b/linux/clipshare_clipboard_listener_plugin_private.h
@@ -25,4 +25,3 @@ static FlMethodResponse *storeCurrentWindowHwnd(ClipshareClipboardListenerPlugin
 static FlMethodResponse *pasteToPreviousWindow(ClipshareClipboardListenerPlugin *self, int64_t delayMs);
 static void sendClipboardData(ClipshareClipboardListenerPlugin *plugin, const gchar *type, const gchar *content);
 static void onWaylandClipboardChanged(GObject *owner, const gchar *type, const gchar *content);
-static void onClipboardChanged(GtkClipboard *clipboard, GdkEvent *event, gpointer data);


### PR DESCRIPTION
## Problem

On Linux the plugin fails to compile under `-Wall -Werror`:

```
clipshare_clipboard_listener_plugin_private.h:28:13: error: unused function 'onClipboardChanged' [-Werror,-Wunused-function]
```

This is fatal for any app built with the standard Flutter Linux desktop template, whose `apply_standard_settings()` applies `-Wall -Werror` to every plugin target. It currently breaks downstream release builds on Flutter 3.44.x.

## Cause

The 1.3.0 Wayland rework routes clipboard-change events through `onWaylandClipboardChanged` and the X11 path. The former GTK `owner-change` handler `onClipboardChanged` no longer has a definition or any caller anywhere under `linux/`, but its `static` forward declaration was left behind in `_private.h`. A `static` function that is declared but never defined or used triggers `-Wunused-function`.

## Fix

Remove the dead forward declaration. No behavioral change -- there is no definition or call site for it in the Linux sources.